### PR TITLE
Review suggestions

### DIFF
--- a/database.go
+++ b/database.go
@@ -59,6 +59,8 @@ func isKnownArch(arch string) bool {
 	return false
 }
 
+// normalizeOS returns the normalized OS. If the os is empty, it returns
+// [runtime.GOOS].
 func normalizeOS(os string) string {
 	if os == "" {
 		return runtime.GOOS

--- a/platforms.go
+++ b/platforms.go
@@ -65,9 +65,11 @@
 // While the OCI platform specifications provide a tool for components to
 // specify structured information, user input typically doesn't need the full
 // context and much can be inferred. To solve this problem, we introduced
-// "specifiers". A specifier has the format
-// `<os>|<arch>|<os>/<arch>[/<variant>]`.  The user can provide either the
-// operating system or the architecture or both.
+// "specifiers". A specifier has the format:
+//
+//	<os>[(<osVersion>)]|<arch>|<os>/<arch>[/<variant>]
+//
+// The user can provide either the operating system or the architecture or both.
 //
 // An example of a common specifier is `linux/amd64`. If the host has a default
 // of runtime that matches this, the user can simply provide the component that


### PR DESCRIPTION
Quick commit of some suggestions for https://github.com/containerd/platforms/pull/6


- Split regex for first (os and version) and further components (arch, variant)
- Update regular expression to preserve the existing set of accepted characters for the OS part of the first element (avoid accepting ".", ")", "(").
- Make regular expression for osVersion more strict, and only accept dot-separated numbers.
- Add capture groups to the osAndVersion regular expression so that the result can be consumed directly, without having to split after validating.
- Now that we already separate OS asnd OSVersion ahead; simplify normalizeOS to only normalize the OS.
- Remove the OSAndVersionFormat variable, and inline it.
- Update Parse() to prevent un-bounded string splitting.